### PR TITLE
add endpoint to redirect user from short code to original URL

### DIFF
--- a/server/src/controllers/links.controller.js
+++ b/server/src/controllers/links.controller.js
@@ -1,5 +1,6 @@
 const {getRandomString} = require('../utils/getRandomString')
 const Link = require('../models/link')
+const {response} = require('express');
 
 getAllLinks = async (req, res) => {
     const allLinks = await Link.find({})
@@ -38,7 +39,21 @@ createLink = async (req, res) => {
     }
 }
 
+getLinkFromCode = async (req,res) => {
+    const short = req.params.short
+    try{
+        const foundLink = await Link.findOne({"short": short})
+        if(!foundLink){
+            return res.status(500).json({ success: false, error: "short link does not exist" })
+        }
+        res.redirect(foundLink.url)
+    }catch(error){
+        res.status(500).json({ success: false, error: "server error" })
+    }
+}
+
 module.exports = {
     getAllLinks,
-    createLink
+    createLink,
+    getLinkFromCode
 }

--- a/server/src/docs.yaml
+++ b/server/src/docs.yaml
@@ -127,3 +127,32 @@ paths:
                     type: boolean
                   message:
                     type: string
+
+  /api/links/{short}:
+    get:
+      tags:
+        - Links
+      description: Get original url from the short code
+      parameters:
+        - in: path
+          name: short
+          schema:
+            type: string
+          required: true
+          description: short code
+      responses:
+        302:
+          description: Successfully get the original URL and redirect the user
+        500:
+          description: cannot get link
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                  - message
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string

--- a/server/src/routes/links.route.js
+++ b/server/src/routes/links.route.js
@@ -3,6 +3,7 @@ const linksController = require('../controllers/links.controller')
 
 router.get('/', linksController.getAllLinks)
 router.post('/', linksController.createLink)
+router.get('/:short', linksController.getLinkFromCode)
 
 
 module.exports = router


### PR DESCRIPTION
## Summary
Add endpoint to redirect user from short code to original url
closes #32 

1. create a new link
###
POST http://localhost:4002/api/links
Content-Type: application/json

{
"url": "https://www.google.com/search?q=javascript&rlz=1C1CHBF_en-GBAU898AU898&sxsrf=ALiCzsZsxzU9mEq1tD9NbJDwm_X_xU9Vrw%3A1664719017794&ei=qZg5Y6eQMNiFmAXuzoiQDA&ved=0ahUKEwjniNPN2cH6AhXYAqYKHW4nAsIQ4dUDCA4&uact=5&oq=javascript&gs_lcp=Cgdnd3Mtd2l6EAMyBAgjECcyBAgjECcyBAgjECcyBwgAELEDEEMyCwguEIAEEMcBEK8BMggIABCABBCxAzIFCAAQgAQyCAgAEIAEELEDMggIABCABBCxAzILCAAQgAQQsQMQgwE6BwgjELADECc6CggAEEcQ1gQQsAM6BwgAELADEEM6DAguEMgDELADEEMYAToPCC4Q1AIQyAMQsAMQQxgBOgUIABCRAjoRCC4QgAQQsQMQgwEQxwEQ0QM6CwguELEDEIMBENQCOggILhCxAxCDAToOCC4QgAQQsQMQxwEQ0QM6BAguEEM6BAgAEEM6CgguELEDEIMBEEM6CggAELEDEIMBEEM6CggAEIAEEIcCEBQ6BwguELEDEEM6DgguEIAEELEDEIMBENQCSgQIQRgASgQIRhgBUL0aWNYiYKclaAFwAXgAgAHaAYgBzQySAQUwLjcuMpgBAKABAcgBEsABAdoBBggBEAEYCA&sclient=gws-wiz"
}

for example if the short code returned is elwtr

entering 
`http://localhost:4002/api/links/elwtr`
in the browser address bar will redirect user to the really long url

- [x] tested locally
- [x] no warnings/errors